### PR TITLE
Use empty string for falsiness

### DIFF
--- a/cloudflare.json
+++ b/cloudflare.json
@@ -49,11 +49,11 @@
                 "options": [
                 {
                     "label": "First visit only",
-                    "value": false
+                    "value": ""
                 },
                 {
                     "label": "Every visit",
-                    "value": true
+                    "value": "on"
                 }
                 ]
             }


### PR DESCRIPTION
We have to do some DB work before we can support non-string config values. For now, we'd like to  use the empty string as the falsey value.
